### PR TITLE
feat(agent): add duplicate memory detection before saving

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 repos:
+
+# Prevent commits directly to main
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0  # Use the latest version
+  hooks:
+    - id: no-commit-to-branch
+      args: [--branch, main]
+
 # Make sure uv.lock file is up to date 
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
 
 # Prevent commits directly to main
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0  # Use the latest version
+  rev: v6.0.0
   hooks:
     - id: no-commit-to-branch
       args: [--branch, main]
@@ -10,7 +10,7 @@ repos:
 # Make sure uv.lock file is up to date 
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.11.0
+  rev: 0.11.7
   hooks:
     # Update the uv lockfile
     - id: uv-lock
@@ -18,7 +18,7 @@ repos:
 # Ruff Hooks (Format & Check)
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.15.7
+  rev: v0.15.10
   hooks:
     # Run the linter.
     - id: ruff-check

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -6,7 +6,7 @@ memory records. The agent itself uses create_agent's built-in MessagesState.
 
 import datetime
 import uuid
-from typing import Any, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 
 class Memory(TypedDict):
@@ -26,3 +26,14 @@ class Memory(TypedDict):
     last_reviewed_at: NotRequired[datetime.datetime | None]
     review_count: NotRequired[int]
     test_score_avg: NotRequired[float]
+
+
+class DuplicateMatch(TypedDict):
+    """A duplicate memory match returned by find_duplicates.
+
+    Represents either an exact text match or a semantic similarity match.
+    """
+
+    content: str
+    similarity: float
+    match_type: Literal["exact", "semantic"]

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from langchain_core.tools import tool
 from langgraph.types import interrupt
 
+from src.db.vector_store import find_duplicates as db_find_duplicates
 from src.db.vector_store import save_memory as db_save_memory
 from src.db.vector_store import search_memories as db_search_memories
 
@@ -50,10 +51,12 @@ async def save_memory_tool(content: str = "", insight: str = "") -> str:
     if not content or not insight:
         return "Please provide both content and insight."
 
-    confirmation = interrupt({"content": content, "insight": insight})
+    duplicates = await db_find_duplicates(content)
+
+    confirmation = interrupt({"content": content, "insight": insight, "duplicates": duplicates})
 
     if not confirmation.get("approved", False):
-        return "Save cancelled."
+        return "Save cancelled by user."
 
     await db_save_memory(content, summary=insight)
     return f"Memory saved: {insight}"

--- a/src/agent/tools_test.py
+++ b/src/agent/tools_test.py
@@ -37,50 +37,126 @@ async def test_search_memories_tool_handles_no_results() -> None:
 
 
 async def test_save_memory_tool_calls_interrupt() -> None:
-    """Test that save_memory_tool calls interrupt with content and insight."""
+    """Test that save_memory_tool calls interrupt with content, insight, and duplicates."""
     from src.agent.tools import save_memory_tool
 
-    with patch("src.agent.tools.interrupt") as mock_interrupt:
-        mock_interrupt.return_value = {"approved": True}
+    with patch("src.agent.tools.db_find_duplicates") as mock_find:
+        mock_find.return_value = []
 
-        with patch("src.agent.tools.db_save_memory") as mock_save:
-            mock_save.return_value = {
-                "id": uuid.UUID("00000000-0000-0000-0000-000000000001"),
-                "content": "I realized that motivation follows action",
-            }
+        with patch("src.agent.tools.interrupt") as mock_interrupt:
+            mock_interrupt.return_value = {"approved": True}
 
-            input_dict: Any = {
-                "content": "I realized that motivation follows action",
-                "insight": "Motivation follows action",
-            }
-            result = await save_memory_tool.ainvoke(input_dict)
+            with patch("src.agent.tools.db_save_memory") as mock_save:
+                mock_save.return_value = {
+                    "id": uuid.UUID("00000000-0000-0000-0000-000000000001"),
+                    "content": "I realized that motivation follows action",
+                }
 
-            mock_interrupt.assert_called_once_with(
-                {
+                input_dict: Any = {
                     "content": "I realized that motivation follows action",
                     "insight": "Motivation follows action",
                 }
-            )
-            mock_save.assert_called_once_with(
-                "I realized that motivation follows action",
-                summary="Motivation follows action",
-            )
-            assert "saved" in result.lower()
+                result = await save_memory_tool.ainvoke(input_dict)
+
+                mock_interrupt.assert_called_once_with(
+                    {
+                        "content": "I realized that motivation follows action",
+                        "insight": "Motivation follows action",
+                        "duplicates": [],
+                    }
+                )
+                mock_save.assert_called_once_with(
+                    "I realized that motivation follows action",
+                    summary="Motivation follows action",
+                )
+                assert "saved" in result.lower()
 
 
 async def test_save_memory_tool_cancelled() -> None:
     """Test that save_memory_tool handles user rejection."""
     from src.agent.tools import save_memory_tool
 
-    with patch("src.agent.tools.interrupt") as mock_interrupt:
-        mock_interrupt.return_value = {"approved": False}
+    with patch("src.agent.tools.db_find_duplicates") as mock_find:
+        mock_find.return_value = []
 
-        with patch("src.agent.tools.db_save_memory") as mock_save:
-            input_dict: Any = {
-                "content": "Some thought",
-                "insight": "A thought",
-            }
-            result = await save_memory_tool.ainvoke(input_dict)
+        with patch("src.agent.tools.interrupt") as mock_interrupt:
+            mock_interrupt.return_value = {"approved": False}
 
-            mock_save.assert_not_called()
-            assert "cancel" in result.lower()
+            with patch("src.agent.tools.db_save_memory") as mock_save:
+                input_dict: Any = {
+                    "content": "Some thought",
+                    "insight": "A thought",
+                }
+                result = await save_memory_tool.ainvoke(input_dict)
+
+                mock_save.assert_not_called()
+                assert "cancel" in result.lower()
+
+
+async def test_save_memory_tool_surfaces_duplicates_in_interrupt() -> None:
+    """Test that save_memory_tool includes duplicates in the interrupt payload."""
+    from src.agent.tools import save_memory_tool
+
+    duplicates = [
+        {"content": "Exercise is good", "similarity": 1.0, "match_type": "exact"},
+    ]
+
+    with patch("src.agent.tools.db_find_duplicates") as mock_find:
+        mock_find.return_value = duplicates
+
+        with patch("src.agent.tools.interrupt") as mock_interrupt:
+            mock_interrupt.return_value = {"approved": True}
+
+            with patch("src.agent.tools.db_save_memory") as mock_save:
+                mock_save.return_value = {
+                    "id": uuid.UUID("00000000-0000-0000-0000-000000000001"),
+                    "content": "Exercise is good",
+                }
+
+                input_dict: Any = {
+                    "content": "Exercise is good",
+                    "insight": "Exercise matters",
+                }
+                result = await save_memory_tool.ainvoke(input_dict)
+
+                mock_find.assert_called_once_with("Exercise is good")
+                mock_interrupt.assert_called_once_with(
+                    {
+                        "content": "Exercise is good",
+                        "insight": "Exercise matters",
+                        "duplicates": duplicates,
+                    }
+                )
+                assert "saved" in result.lower()
+
+
+async def test_save_memory_tool_sends_empty_duplicates_when_none_found() -> None:
+    """Test that save_memory_tool sends empty duplicates list when no matches."""
+    from src.agent.tools import save_memory_tool
+
+    with patch("src.agent.tools.db_find_duplicates") as mock_find:
+        mock_find.return_value = []
+
+        with patch("src.agent.tools.interrupt") as mock_interrupt:
+            mock_interrupt.return_value = {"approved": True}
+
+            with patch("src.agent.tools.db_save_memory") as mock_save:
+                mock_save.return_value = {
+                    "id": uuid.UUID("00000000-0000-0000-0000-000000000002"),
+                    "content": "Brand new insight",
+                }
+
+                input_dict: Any = {
+                    "content": "Brand new insight",
+                    "insight": "Something new",
+                }
+                result = await save_memory_tool.ainvoke(input_dict)
+
+                mock_interrupt.assert_called_once_with(
+                    {
+                        "content": "Brand new insight",
+                        "insight": "Something new",
+                        "duplicates": [],
+                    }
+                )
+                assert "saved" in result.lower()

--- a/src/agent/tools_test.py
+++ b/src/agent/tools_test.py
@@ -40,57 +40,58 @@ async def test_save_memory_tool_calls_interrupt() -> None:
     """Test that save_memory_tool calls interrupt with content, insight, and duplicates."""
     from src.agent.tools import save_memory_tool
 
-    with patch("src.agent.tools.db_find_duplicates") as mock_find:
+    with (
+        patch("src.agent.tools.db_find_duplicates") as mock_find,
+        patch("src.agent.tools.interrupt") as mock_interrupt,
+        patch("src.agent.tools.db_save_memory") as mock_save,
+    ):
         mock_find.return_value = []
+        mock_interrupt.return_value = {"approved": True}
+        mock_save.return_value = {
+            "id": uuid.UUID("00000000-0000-0000-0000-000000000001"),
+            "content": "I realized that motivation follows action",
+        }
 
-        with patch("src.agent.tools.interrupt") as mock_interrupt:
-            mock_interrupt.return_value = {"approved": True}
+        input_dict: Any = {
+            "content": "I realized that motivation follows action",
+            "insight": "Motivation follows action",
+        }
+        result = await save_memory_tool.ainvoke(input_dict)
 
-            with patch("src.agent.tools.db_save_memory") as mock_save:
-                mock_save.return_value = {
-                    "id": uuid.UUID("00000000-0000-0000-0000-000000000001"),
-                    "content": "I realized that motivation follows action",
-                }
-
-                input_dict: Any = {
-                    "content": "I realized that motivation follows action",
-                    "insight": "Motivation follows action",
-                }
-                result = await save_memory_tool.ainvoke(input_dict)
-
-                mock_interrupt.assert_called_once_with(
-                    {
-                        "content": "I realized that motivation follows action",
-                        "insight": "Motivation follows action",
-                        "duplicates": [],
-                    }
-                )
-                mock_save.assert_called_once_with(
-                    "I realized that motivation follows action",
-                    summary="Motivation follows action",
-                )
-                assert "saved" in result.lower()
+        mock_interrupt.assert_called_once_with(
+            {
+                "content": "I realized that motivation follows action",
+                "insight": "Motivation follows action",
+                "duplicates": [],
+            }
+        )
+        mock_save.assert_called_once_with(
+            "I realized that motivation follows action",
+            summary="Motivation follows action",
+        )
+        assert "saved" in result.lower()
 
 
 async def test_save_memory_tool_cancelled() -> None:
     """Test that save_memory_tool handles user rejection."""
     from src.agent.tools import save_memory_tool
 
-    with patch("src.agent.tools.db_find_duplicates") as mock_find:
+    with (
+        patch("src.agent.tools.db_find_duplicates") as mock_find,
+        patch("src.agent.tools.interrupt") as mock_interrupt,
+        patch("src.agent.tools.db_save_memory") as mock_save,
+    ):
         mock_find.return_value = []
+        mock_interrupt.return_value = {"approved": False}
 
-        with patch("src.agent.tools.interrupt") as mock_interrupt:
-            mock_interrupt.return_value = {"approved": False}
+        input_dict: Any = {
+            "content": "Some thought",
+            "insight": "A thought",
+        }
+        result = await save_memory_tool.ainvoke(input_dict)
 
-            with patch("src.agent.tools.db_save_memory") as mock_save:
-                input_dict: Any = {
-                    "content": "Some thought",
-                    "insight": "A thought",
-                }
-                result = await save_memory_tool.ainvoke(input_dict)
-
-                mock_save.assert_not_called()
-                assert "cancel" in result.lower()
+        mock_save.assert_not_called()
+        assert "cancel" in result.lower()
 
 
 async def test_save_memory_tool_surfaces_duplicates_in_interrupt() -> None:
@@ -101,62 +102,62 @@ async def test_save_memory_tool_surfaces_duplicates_in_interrupt() -> None:
         {"content": "Exercise is good", "similarity": 1.0, "match_type": "exact"},
     ]
 
-    with patch("src.agent.tools.db_find_duplicates") as mock_find:
+    with (
+        patch("src.agent.tools.db_find_duplicates") as mock_find,
+        patch("src.agent.tools.interrupt") as mock_interrupt,
+        patch("src.agent.tools.db_save_memory") as mock_save,
+    ):
         mock_find.return_value = duplicates
+        mock_interrupt.return_value = {"approved": True}
+        mock_save.return_value = {
+            "id": uuid.UUID("00000000-0000-0000-0000-000000000001"),
+            "content": "Exercise is good",
+        }
 
-        with patch("src.agent.tools.interrupt") as mock_interrupt:
-            mock_interrupt.return_value = {"approved": True}
+        input_dict: Any = {
+            "content": "Exercise is good",
+            "insight": "Exercise matters",
+        }
+        result = await save_memory_tool.ainvoke(input_dict)
 
-            with patch("src.agent.tools.db_save_memory") as mock_save:
-                mock_save.return_value = {
-                    "id": uuid.UUID("00000000-0000-0000-0000-000000000001"),
-                    "content": "Exercise is good",
-                }
-
-                input_dict: Any = {
-                    "content": "Exercise is good",
-                    "insight": "Exercise matters",
-                }
-                result = await save_memory_tool.ainvoke(input_dict)
-
-                mock_find.assert_called_once_with("Exercise is good")
-                mock_interrupt.assert_called_once_with(
-                    {
-                        "content": "Exercise is good",
-                        "insight": "Exercise matters",
-                        "duplicates": duplicates,
-                    }
-                )
-                assert "saved" in result.lower()
+        mock_find.assert_called_once_with("Exercise is good")
+        mock_interrupt.assert_called_once_with(
+            {
+                "content": "Exercise is good",
+                "insight": "Exercise matters",
+                "duplicates": duplicates,
+            }
+        )
+        assert "saved" in result.lower()
 
 
 async def test_save_memory_tool_sends_empty_duplicates_when_none_found() -> None:
     """Test that save_memory_tool sends empty duplicates list when no matches."""
     from src.agent.tools import save_memory_tool
 
-    with patch("src.agent.tools.db_find_duplicates") as mock_find:
+    with (
+        patch("src.agent.tools.db_find_duplicates") as mock_find,
+        patch("src.agent.tools.interrupt") as mock_interrupt,
+        patch("src.agent.tools.db_save_memory") as mock_save,
+    ):
         mock_find.return_value = []
+        mock_interrupt.return_value = {"approved": True}
+        mock_save.return_value = {
+            "id": uuid.UUID("00000000-0000-0000-0000-000000000002"),
+            "content": "Brand new insight",
+        }
 
-        with patch("src.agent.tools.interrupt") as mock_interrupt:
-            mock_interrupt.return_value = {"approved": True}
+        input_dict: Any = {
+            "content": "Brand new insight",
+            "insight": "Something new",
+        }
+        result = await save_memory_tool.ainvoke(input_dict)
 
-            with patch("src.agent.tools.db_save_memory") as mock_save:
-                mock_save.return_value = {
-                    "id": uuid.UUID("00000000-0000-0000-0000-000000000002"),
-                    "content": "Brand new insight",
-                }
-
-                input_dict: Any = {
-                    "content": "Brand new insight",
-                    "insight": "Something new",
-                }
-                result = await save_memory_tool.ainvoke(input_dict)
-
-                mock_interrupt.assert_called_once_with(
-                    {
-                        "content": "Brand new insight",
-                        "insight": "Something new",
-                        "duplicates": [],
-                    }
-                )
-                assert "saved" in result.lower()
+        mock_interrupt.assert_called_once_with(
+            {
+                "content": "Brand new insight",
+                "insight": "Something new",
+                "duplicates": [],
+            }
+        )
+        assert "saved" in result.lower()

--- a/src/api/bot.py
+++ b/src/api/bot.py
@@ -144,6 +144,7 @@ async def handle_message(
             interrupt_value = state.tasks[0].interrupts[0].value
             insight = interrupt_value.get("insight", "")
             content = interrupt_value.get("content", "")
+            duplicates = interrupt_value.get("duplicates", [])
 
             keyboard = InlineKeyboardMarkup(
                 [
@@ -154,10 +155,20 @@ async def handle_message(
                 ]
             )
 
-            confirm_text = truncate_for_telegram(
+            confirm_parts = [
                 f"💡 Save this insight?\n\n"
                 f"<blockquote>{insight}</blockquote>\n\n"
                 f'<i>Original: "{content}"</i>',
+            ]
+
+            if duplicates:
+                confirm_parts.append("\n\n⚠️ <b>Similar memories found:</b>")
+                for dup in duplicates:
+                    label = "exact" if dup["match_type"] == "exact" else "similar"
+                    confirm_parts.append(f"• [{label}] {dup['content']}")
+
+            confirm_text = truncate_for_telegram(
+                "\n".join(confirm_parts),
                 max_len=telegram_char_limit,
             )
             try:

--- a/src/api/bot_test.py
+++ b/src/api/bot_test.py
@@ -197,3 +197,91 @@ async def test_handle_callback_cancelled(
         call_args = mock_graph.ainvoke.call_args
         command = call_args[0][0]
         assert command.resume == {"approved": False}
+
+
+async def test_handle_message_interrupt_shows_duplicates(
+    mock_update: Update,
+    mock_context: MagicMock,
+) -> None:
+    """Test that the save confirmation UI surfaces duplicate memories."""
+    from src.api.bot import handle_message
+
+    async def mock_astream(*args: Any, **kwargs: Any) -> AsyncGenerator[dict[str, Any], None]:
+        yield {
+            "event": "on_chat_model_stream",
+            "data": {"chunk": MagicMock(content="Let me save that")},
+        }
+
+    mock_interrupt = MagicMock()
+    mock_interrupt.value = {
+        "insight": "Exercise matters",
+        "content": "Exercise is good",
+        "duplicates": [
+            {"content": "Exercise is good", "similarity": 1.0, "match_type": "exact"},
+            {
+                "content": "Working out is healthy",
+                "similarity": 0.91,
+                "match_type": "semantic",
+            },
+        ],
+    }
+
+    mock_task = MagicMock()
+    mock_task.interrupts = [mock_interrupt]
+
+    mock_state = MagicMock()
+    mock_state.next = ["some_node"]
+    mock_state.tasks = [mock_task]
+
+    mock_graph = MagicMock()
+    mock_graph.astream_events = mock_astream
+    mock_graph.aget_state = AsyncMock(return_value=mock_state)
+
+    with patch("src.api.bot._get_graph", return_value=mock_graph):
+        await handle_message(mock_update, mock_context)
+
+        last_call = mock_context.bot.edit_message_text.call_args
+        text = last_call.kwargs.get("text", last_call[1].get("text", ""))
+        assert "Exercise is good" in text
+        assert "Working out is healthy" in text
+        assert "Similar" in text or "Duplicate" in text or "duplicate" in text
+
+
+async def test_handle_message_interrupt_no_duplicates(
+    mock_update: Update,
+    mock_context: MagicMock,
+) -> None:
+    """Test that the save confirmation UI works when no duplicates are found."""
+    from src.api.bot import handle_message
+
+    async def mock_astream(*args: Any, **kwargs: Any) -> AsyncGenerator[dict[str, Any], None]:
+        yield {
+            "event": "on_chat_model_stream",
+            "data": {"chunk": MagicMock(content="Let me save that")},
+        }
+
+    mock_interrupt = MagicMock()
+    mock_interrupt.value = {
+        "insight": "Brand new insight",
+        "content": "Something new",
+        "duplicates": [],
+    }
+
+    mock_task = MagicMock()
+    mock_task.interrupts = [mock_interrupt]
+
+    mock_state = MagicMock()
+    mock_state.next = ["some_node"]
+    mock_state.tasks = [mock_task]
+
+    mock_graph = MagicMock()
+    mock_graph.astream_events = mock_astream
+    mock_graph.aget_state = AsyncMock(return_value=mock_state)
+
+    with patch("src.api.bot._get_graph", return_value=mock_graph):
+        await handle_message(mock_update, mock_context)
+
+        last_call = mock_context.bot.edit_message_text.call_args
+        text = last_call.kwargs.get("text", last_call[1].get("text", ""))
+        assert "Save this insight?" in text
+        assert "duplicate" not in text.lower()

--- a/src/db/vector_store.py
+++ b/src/db/vector_store.py
@@ -134,3 +134,51 @@ async def search_memories(
         [r.get("similarity") for r in results],
     )
     return results
+
+
+async def find_duplicates(content: str) -> list[dict[str, object]]:
+    """Check for duplicate memories by exact text match and semantic similarity.
+
+    Performs two checks:
+    1. Exact text match via Supabase query (no embedding cost).
+    2. Semantic similarity search with a 0.85 threshold (top 3).
+
+    Results are deduplicated — an exact match that also appears in the
+    semantic results is only returned once (as "exact").
+
+    Args:
+        content: The memory content to check for duplicates.
+
+    Returns:
+        A list of duplicate records, each containing 'content',
+        'similarity', and 'match_type' ("exact" or "semantic").
+    """
+    client = get_supabase_client()
+
+    # Step 1: Exact text match
+    exact_response = client.table("memories").select("id, content").eq("content", content).execute()
+    exact_contents: set[str] = set()
+    results: list[dict[str, object]] = []
+    for row in exact_response.data:
+        exact_contents.add(row["content"])
+        results.append(
+            {
+                "content": row["content"],
+                "similarity": 1.0,
+                "match_type": "exact",
+            }
+        )
+
+    # Step 2: Semantic similarity search
+    semantic_matches = await search_memories(content, top_k=3, threshold=0.85)
+    for match in semantic_matches:
+        if match["content"] not in exact_contents:
+            results.append(
+                {
+                    "content": match["content"],
+                    "similarity": match.get("similarity", 0.0),
+                    "match_type": "semantic",
+                }
+            )
+
+    return results

--- a/src/db/vector_store.py
+++ b/src/db/vector_store.py
@@ -17,7 +17,7 @@ from langchain_community.vectorstores import SupabaseVectorStore
 from langchain_core.documents import Document
 from langchain_google_genai import GoogleGenerativeAIEmbeddings
 
-from src.agent.state import Memory
+from src.agent.state import DuplicateMatch, Memory
 from src.db.client import get_supabase_client
 
 logger = logging.getLogger(__name__)
@@ -136,7 +136,7 @@ async def search_memories(
     return results
 
 
-async def find_duplicates(content: str) -> list[dict[str, object]]:
+async def find_duplicates(content: str) -> list[DuplicateMatch]:
     """Check for duplicate memories by exact text match and semantic similarity.
 
     Performs two checks:
@@ -155,10 +155,12 @@ async def find_duplicates(content: str) -> list[dict[str, object]]:
     """
     client = get_supabase_client()
 
-    # Step 1: Exact text match
-    exact_response = client.table("memories").select("id, content").eq("content", content).execute()
+    # Step 1: Exact text match (wrap sync client call to avoid blocking the event loop)
+    exact_response = await asyncio.to_thread(
+        client.table("memories").select("id, content").eq("content", content).execute
+    )
     exact_contents: set[str] = set()
-    results: list[dict[str, object]] = []
+    results: list[DuplicateMatch] = []
     for row in exact_response.data:
         exact_contents.add(row["content"])
         results.append(

--- a/src/db/vector_store_test.py
+++ b/src/db/vector_store_test.py
@@ -120,3 +120,139 @@ async def test_search_memories_uses_query_directly(
                 mock_vector_store.similarity_search_with_relevance_scores.assert_called_once_with(
                     "What are my habits?", k=3
                 )
+
+
+async def test_find_duplicates_returns_exact_match(
+    mock_settings: MagicMock,
+) -> None:
+    """Test that find_duplicates detects an exact content match."""
+    from src.db.vector_store import _get_embeddings, _get_vector_store, find_duplicates
+
+    mock_client = MagicMock()
+    # Simulate Supabase .table().select().eq().execute() returning one row
+    mock_execute = MagicMock()
+    mock_execute.data = [
+        {"id": "00000000-0000-0000-0000-000000000001", "content": "Exercise is good"}
+    ]
+    mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+        mock_execute
+    )
+
+    mock_vector_store = MagicMock()
+    # No semantic matches (exact match only)
+    mock_vector_store.similarity_search_with_relevance_scores = MagicMock(return_value=[])
+
+    with patch("src.db.vector_store.SupabaseVectorStore", return_value=mock_vector_store):
+        with patch("src.db.vector_store.get_supabase_client", return_value=mock_client):
+            with patch("src.core.config.get_settings", return_value=mock_settings):
+                _get_embeddings.cache_clear()
+                _get_vector_store.cache_clear()
+
+                result = await find_duplicates("Exercise is good")
+
+                assert len(result) == 1
+                assert result[0]["content"] == "Exercise is good"
+                assert result[0]["match_type"] == "exact"
+                assert result[0]["similarity"] == 1.0
+
+
+async def test_find_duplicates_returns_empty_when_no_matches(
+    mock_settings: MagicMock,
+) -> None:
+    """Test that find_duplicates returns empty list when no duplicates exist."""
+    from src.db.vector_store import _get_embeddings, _get_vector_store, find_duplicates
+
+    mock_client = MagicMock()
+    mock_execute = MagicMock()
+    mock_execute.data = []
+    mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+        mock_execute
+    )
+
+    mock_vector_store = MagicMock()
+    mock_vector_store.similarity_search_with_relevance_scores = MagicMock(return_value=[])
+
+    with patch("src.db.vector_store.SupabaseVectorStore", return_value=mock_vector_store):
+        with patch("src.db.vector_store.get_supabase_client", return_value=mock_client):
+            with patch("src.core.config.get_settings", return_value=mock_settings):
+                _get_embeddings.cache_clear()
+                _get_vector_store.cache_clear()
+
+                result = await find_duplicates("Something totally new")
+
+                assert result == []
+
+
+async def test_find_duplicates_returns_semantic_matches(
+    mock_settings: MagicMock,
+) -> None:
+    """Test that find_duplicates returns semantic matches above 0.85 threshold."""
+    from src.db.vector_store import _get_embeddings, _get_vector_store, find_duplicates
+
+    mock_client = MagicMock()
+    mock_execute = MagicMock()
+    mock_execute.data = []  # No exact match
+    mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+        mock_execute
+    )
+
+    mock_vector_store = MagicMock()
+    mock_vector_store.similarity_search_with_relevance_scores = MagicMock(
+        return_value=[
+            (MagicMock(page_content="Working out is key to staying healthy", metadata={}), 0.91),
+        ]
+    )
+
+    with patch("src.db.vector_store.SupabaseVectorStore", return_value=mock_vector_store):
+        with patch("src.db.vector_store.get_supabase_client", return_value=mock_client):
+            with patch("src.core.config.get_settings", return_value=mock_settings):
+                _get_embeddings.cache_clear()
+                _get_vector_store.cache_clear()
+
+                result = await find_duplicates("Exercise is good for health")
+
+                assert len(result) == 1
+                assert result[0]["content"] == "Working out is key to staying healthy"
+                assert result[0]["match_type"] == "semantic"
+                assert result[0]["similarity"] == 0.91
+
+
+async def test_find_duplicates_deduplicates_exact_and_semantic_overlap(
+    mock_settings: MagicMock,
+) -> None:
+    """Test exact+semantic overlap is deduplicated, returning only once as 'exact'."""
+    from src.db.vector_store import _get_embeddings, _get_vector_store, find_duplicates
+
+    mock_client = MagicMock()
+    mock_execute = MagicMock()
+    mock_execute.data = [
+        {"id": "00000000-0000-0000-0000-000000000001", "content": "Exercise is good"}
+    ]
+    mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+        mock_execute
+    )
+
+    mock_vector_store = MagicMock()
+    # Same content also shows up as a semantic match
+    mock_vector_store.similarity_search_with_relevance_scores = MagicMock(
+        return_value=[
+            (MagicMock(page_content="Exercise is good", metadata={}), 0.99),
+            (MagicMock(page_content="Working out is healthy", metadata={}), 0.88),
+        ]
+    )
+
+    with patch("src.db.vector_store.SupabaseVectorStore", return_value=mock_vector_store):
+        with patch("src.db.vector_store.get_supabase_client", return_value=mock_client):
+            with patch("src.core.config.get_settings", return_value=mock_settings):
+                _get_embeddings.cache_clear()
+                _get_vector_store.cache_clear()
+
+                result = await find_duplicates("Exercise is good")
+
+                assert len(result) == 2
+                # First result is the exact match (not duplicated)
+                exact_results = [r for r in result if r["match_type"] == "exact"]
+                semantic_results = [r for r in result if r["match_type"] == "semantic"]
+                assert len(exact_results) == 1
+                assert len(semantic_results) == 1
+                assert semantic_results[0]["content"] == "Working out is healthy"


### PR DESCRIPTION
Fix #9 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Memory saving now detects and displays duplicate or similar entries before user confirmation

* **Improvements**
  * Clearer cancellation messaging when declining to save a memory

<!-- end of auto-generated comment: release notes by coderabbit.ai -->