### PR TITLE
fix: correct thread_id validation for private-chat-only design

### DIFF
--- a/src/api/bot_callbacks.py
+++ b/src/api/bot_callbacks.py
@@ -183,7 +183,7 @@ async def handle_callback(
     callback_chat_id = parts[2] if len(parts) > 2 else ""
     approved = action == "save_yes"
 
-    expected_thread_id = f"{query.message.chat.id}_{query.from_user.id}"
+    expected_thread_id = str(query.message.chat.id)
     if callback_chat_id != str(query.message.chat.id) or thread_id != expected_thread_id:
         try:
             await query.edit_message_text(text="Please run /start first.")

--- a/src/api/bot_callbacks_test.py
+++ b/src/api/bot_callbacks_test.py
@@ -30,7 +30,7 @@ def mock_context() -> MagicMock:
 def mock_callback_update(mock_user: MagicMock) -> Update:
     """Create a mock Telegram Update with callback query."""
     mock_query = MagicMock()
-    mock_query.data = "save_yes|67890_12345|67890"
+    mock_query.data = "save_yes|67890|67890"
     mock_query.answer = AsyncMock()
     mock_query.edit_message_text = AsyncMock()
     mock_query.from_user = mock_user
@@ -95,7 +95,7 @@ async def test_handle_callback_approved(
     config = call_args.kwargs.get("config", {})
 
     assert command.resume == {"approved": True}
-    assert config["configurable"]["thread_id"] == "67890_12345"
+    assert config["configurable"]["thread_id"] == "67890"
     assert config["configurable"]["user_settings_id"] == "settings-1"
 
     assert mock_callback_update.callback_query is not None
@@ -110,7 +110,7 @@ async def test_handle_callback_cancelled(
     from src.api.bot_callbacks import handle_callback
 
     assert mock_callback_update.callback_query is not None
-    cast(Any, mock_callback_update.callback_query).data = "save_no|67890_12345|67890"
+    cast(Any, mock_callback_update.callback_query).data = "save_no|67890|67890"
 
     mock_graph = MagicMock()
     mock_result_msg = MagicMock()
@@ -131,7 +131,7 @@ async def test_handle_callback_cancelled(
     config = call_args.kwargs.get("config", {})
 
     assert command.resume == {"approved": False}
-    assert config["configurable"]["thread_id"] == "67890_12345"
+    assert config["configurable"]["thread_id"] == "67890"
     assert config["configurable"]["user_settings_id"] == "settings-1"
 
 


### PR DESCRIPTION
  - Fix thread_id validation in bot_callbacks.py to use str(chat_id) format
  - Update test fixtures to match actual thread_id format (chat_id only)
  - Remove obsolete chat_id_user_id format from validation logic

Now correctly validates callback thread_ids, fixing the  "Please run /start first" error when saving memories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved save confirmation callback validation logic for more reliable message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->