### PR TITLE
Message trim

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ EMBEDDING_MODEL=
 # Search Configuration (optional - leave blank to use defaults)
 SEARCH_TOP_K=
 
+# Message trim configuration (optional - leave blank to use defaults)
+# A turn is one user message plus all subsequent AI/tool responses.
+# Number of turns to keep in context window (default: 5)
+MAX_TURNS=
+
 # LLM for evaluation (optional - leave blank to use defaults)
 EVAL_LLM_MODEL=
 EVAL_LLM_PROVIDER=

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -16,6 +16,7 @@ from langchain_core.language_models.chat_models import BaseChatModel
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.graph.state import CompiledStateGraph
 
+from src.agent.middleware import trim_messages_by_turns
 from src.agent.tools import save_memory_tool, search_memories_tool
 
 SYSTEM_PROMPT = """
@@ -213,7 +214,7 @@ def build_graph(
         tools=[save_memory_tool, search_memories_tool],
         system_prompt=SYSTEM_PROMPT,
         checkpointer=checkpointer,
-        middleware=[ToolCallLimitMiddleware(run_limit=5)],
+        middleware=[trim_messages_by_turns, ToolCallLimitMiddleware(run_limit=5)],  # type: ignore[arg-type]
     )
 
     return agent

--- a/src/agent/graph_test.py
+++ b/src/agent/graph_test.py
@@ -33,6 +33,7 @@ async def test_graph_query_flow() -> None:
                 mock_settings.llm_provider = "openai"
                 mock_settings.openai_api_key.get_secret_value.return_value = "test-key"
                 mock_settings.llm_provider_base_url = "https://api.openai.com/v1"
+                mock_settings.max_turns = 5
                 mock_settings_cls.return_value = mock_settings
 
                 from langchain_core.messages import AIMessage
@@ -63,3 +64,24 @@ async def test_graph_query_flow() -> None:
     finally:
         _get_llm.cache_clear()
         get_settings.cache_clear()
+
+
+def test_build_graph_includes_trim_middleware() -> None:
+    """build_graph includes trim_messages_by_turns in the middleware list."""
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    from src.agent.graph import build_graph
+
+    with patch("src.agent.graph._get_llm") as mock_get_llm:
+        with patch("src.agent.graph.create_agent") as mock_create_agent:
+            mock_get_llm.return_value = MagicMock()
+            mock_create_agent.return_value = MagicMock()
+            build_graph(checkpointer=InMemorySaver())
+
+            call_kwargs = mock_create_agent.call_args.kwargs
+            middleware_list = call_kwargs.get("middleware", [])
+            middleware_names = [
+                getattr(m, "__name__", "") or getattr(m, "name", "") or type(m).__name__
+                for m in middleware_list
+            ]
+            assert "trim_messages_by_turns" in middleware_names

--- a/src/agent/graph_test.py
+++ b/src/agent/graph_test.py
@@ -85,3 +85,6 @@ def test_build_graph_includes_trim_middleware() -> None:
                 for m in middleware_list
             ]
             assert "trim_messages_by_turns" in middleware_names
+            trim_idx = middleware_names.index("trim_messages_by_turns")
+            tool_limit_idx = middleware_names.index("ToolCallLimitMiddleware")
+            assert trim_idx < tool_limit_idx

--- a/src/agent/middleware.py
+++ b/src/agent/middleware.py
@@ -1,0 +1,105 @@
+"""Middleware for the ThinkBack agent.
+
+Provides a turn-based message trimming middleware that keeps
+the last N conversation turns to prevent context window bloat.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from langchain.agents.middleware import before_model
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+
+from src.core.config import get_settings
+
+
+def split_into_turns(messages: Sequence[BaseMessage]) -> list[list[BaseMessage]]:
+    """Split a flat message list into turn groups.
+
+    A turn starts with a HumanMessage and includes all subsequent
+    messages until the next HumanMessage. Messages before the first
+    HumanMessage are prepended to the first turn.
+
+    Args:
+        messages: Flat list of conversation messages (no SystemMessages expected).
+
+    Returns:
+        List of turn groups, where each group is a list of messages.
+    """
+    if not messages:
+        return []
+
+    turns: list[list[BaseMessage]] = []
+    current: list[BaseMessage] = []
+    seen_human = False
+
+    for msg in messages:
+        if isinstance(msg, HumanMessage):
+            if seen_human and current:
+                turns.append(current)
+                current = []
+            seen_human = True
+        current.append(msg)
+
+    if current:
+        turns.append(current)
+
+    return turns
+
+
+def _trim_messages_by_turns_impl(state: dict[str, Any], runtime: Any) -> dict[str, Any] | None:
+    """Implementation of turn-based message trimming logic.
+
+    Preserves all SystemMessages at the start. Groups remaining messages
+    into turns (each starting with a HumanMessage) and keeps only the
+    last ``max_turns`` turns.
+
+    Args:
+        state: The current agent state containing messages.
+        runtime: The LangGraph runtime (unused).
+
+    Returns:
+        Updated state with trimmed messages, or None if no trimming needed.
+    """
+    messages = state.get("messages", [])
+    if not messages:
+        return None
+
+    system_msgs = []
+    conversation = []
+    for msg in messages:
+        if isinstance(msg, SystemMessage) and not conversation:
+            system_msgs.append(msg)
+        else:
+            conversation.append(msg)
+
+    turns = split_into_turns(conversation)
+
+    settings = get_settings()
+    if len(turns) <= settings.max_turns:
+        return None
+
+    kept_turns = turns[-settings.max_turns :]
+    kept_messages = [msg for turn in kept_turns for msg in turn]
+
+    return {"messages": system_msgs + kept_messages}
+
+
+@before_model
+def trim_messages_by_turns(state: dict[str, Any], runtime: Any) -> dict[str, Any] | None:
+    """Trim conversation history to the last N turns before each LLM call.
+
+    Preserves all SystemMessages at the start. Groups remaining messages
+    into turns (each starting with a HumanMessage) and keeps only the
+    last ``max_turns`` turns.
+
+    Args:
+        state: The current agent state containing messages.
+        runtime: The LangGraph runtime (unused).
+
+    Returns:
+        Updated state with trimmed messages, or None if no trimming needed.
+    """
+    return _trim_messages_by_turns_impl(state, runtime)

--- a/src/agent/middleware.py
+++ b/src/agent/middleware.py
@@ -6,94 +6,72 @@ the last N conversation turns to prevent context window bloat.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import Any
 
 from langchain.agents.middleware import before_model
-from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+from langchain_core.messages import (
+    BaseMessage,
+    HumanMessage,
+    RemoveMessage,
+    trim_messages,
+)
 
 from src.core.config import get_settings
 
 
-def split_into_turns(messages: Sequence[BaseMessage]) -> list[list[BaseMessage]]:
-    """Split a flat message list into turn groups.
-
-    A turn starts with a HumanMessage and includes all subsequent
-    messages until the next HumanMessage. Messages before the first
-    HumanMessage are prepended to the first turn.
-
-    Args:
-        messages: Flat list of conversation messages (no SystemMessages expected).
-
-    Returns:
-        List of turn groups, where each group is a list of messages.
-    """
-    if not messages:
-        return []
-
-    turns: list[list[BaseMessage]] = []
-    current: list[BaseMessage] = []
-    seen_human = False
-
-    for msg in messages:
-        if isinstance(msg, HumanMessage):
-            if seen_human and current:
-                turns.append(current)
-                current = []
-            seen_human = True
-        current.append(msg)
-
-    if current:
-        turns.append(current)
-
-    return turns
-
-
 def _trim_messages_by_turns_impl(state: dict[str, Any], runtime: Any) -> dict[str, Any] | None:
-    """Implementation of turn-based message trimming logic.
+    """Implementation of turn-based message trimming logic using trim_messages.
 
-    Preserves all SystemMessages at the start. Groups remaining messages
-    into turns (each starting with a HumanMessage) and keeps only the
-    last ``max_turns`` turns.
+    A "turn" is counted as one HumanMessage and all subsequent non-Human
+    messages (AIMessages, ToolMessages, etc.) until the next HumanMessage.
+    Uses a custom turn counter that counts HumanMessages to keep only the
+    last ``max_turns`` turns. Preserves the initial SystemMessage.
 
     Args:
         state: The current agent state containing messages.
         runtime: The LangGraph runtime (unused).
 
     Returns:
-        Updated state with trimmed messages, or None if no trimming needed.
+        Update dictionary with RemoveMessage objects for dropped messages,
+        or None if no trimming needed.
     """
     messages = state.get("messages", [])
     if not messages:
         return None
 
-    system_msgs = []
-    conversation = []
-    for msg in messages:
-        if isinstance(msg, SystemMessage) and not conversation:
-            system_msgs.append(msg)
-        else:
-            conversation.append(msg)
-
-    turns = split_into_turns(conversation)
-
     settings = get_settings()
-    if len(turns) <= settings.max_turns:
+
+    def turn_counter(msgs: list[BaseMessage]) -> int:
+        return sum(1 for m in msgs if isinstance(m, HumanMessage))
+
+    kept = trim_messages(
+        messages,
+        max_tokens=settings.max_turns,
+        token_counter=turn_counter,
+        strategy="last",
+        start_on="human",
+        include_system=True,
+        allow_partial=False,
+    )
+
+    if len(kept) == len(messages):
         return None
 
-    kept_turns = turns[-settings.max_turns :]
-    kept_messages = [msg for turn in kept_turns for msg in turn]
+    # Compute difference to generate RemoveMessage objects for LangGraph state
+    kept_ids = {m.id for m in kept if m.id}
+    remove_msgs = [RemoveMessage(id=m.id) for m in messages if m.id and m.id not in kept_ids]
 
-    return {"messages": system_msgs + kept_messages}
+    return {"messages": remove_msgs} if remove_msgs else None
 
 
 @before_model
 def trim_messages_by_turns(state: dict[str, Any], runtime: Any) -> dict[str, Any] | None:
     """Trim conversation history to the last N turns before each LLM call.
 
-    Preserves all SystemMessages at the start. Groups remaining messages
-    into turns (each starting with a HumanMessage) and keeps only the
-    last ``max_turns`` turns.
+    A "turn" is defined as one HumanMessage plus all subsequent messages
+    (AI responses, tool calls, tool results) until the next HumanMessage.
+    Preserves the initial SystemMessage and keeps only the last
+    ``max_turns`` turns.
 
     Args:
         state: The current agent state containing messages.

--- a/src/agent/middleware_test.py
+++ b/src/agent/middleware_test.py
@@ -1,0 +1,169 @@
+"""Tests for turn-based message trim middleware."""
+
+from unittest.mock import MagicMock, patch
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
+
+from src.agent.middleware import _trim_messages_by_turns_impl, split_into_turns
+
+
+def test_split_single_turn() -> None:
+    """A single user-assistant exchange is one turn."""
+    msgs: list[BaseMessage] = [
+        HumanMessage(content="hi"),
+        AIMessage(content="hello"),
+    ]
+    turns = split_into_turns(msgs)
+    assert len(turns) == 1
+    assert len(turns[0]) == 2
+
+
+def test_split_multiple_turns() -> None:
+    """Each HumanMessage starts a new turn."""
+    msgs: list[BaseMessage] = [
+        HumanMessage(content="q1"),
+        AIMessage(content="a1"),
+        HumanMessage(content="q2"),
+        AIMessage(content="a2"),
+        HumanMessage(content="q3"),
+        AIMessage(content="a3"),
+    ]
+    turns = split_into_turns(msgs)
+    assert len(turns) == 3
+
+
+def test_split_turn_with_tool_calls() -> None:
+    """Tool call chains stay within the same turn."""
+    msgs: list[BaseMessage] = [
+        HumanMessage(content="search something"),
+        AIMessage(content="", tool_calls=[{"name": "search", "args": {"q": "x"}, "id": "1"}]),
+        ToolMessage(content="result", tool_call_id="1"),
+        AIMessage(content="here's what I found"),
+    ]
+    turns = split_into_turns(msgs)
+    assert len(turns) == 1
+    assert len(turns[0]) == 4
+
+
+def test_split_orphan_ai_messages() -> None:
+    """Standalone AIMessages before the first HumanMessage are grouped with the first turn."""
+    msgs: list[BaseMessage] = [
+        AIMessage(content="reminder"),
+        HumanMessage(content="thanks"),
+        AIMessage(content="you're welcome"),
+    ]
+    turns = split_into_turns(msgs)
+    assert len(turns) == 1
+    assert len(turns[0]) == 3
+
+
+def test_split_empty_list() -> None:
+    """Empty message list returns empty turns."""
+    turns = split_into_turns([])
+    assert turns == []
+
+
+def test_split_excludes_system_messages() -> None:
+    """SystemMessages should not be passed to split_into_turns.
+
+    This test documents that if they are, they don't start turns
+    (they'd be grouped with the next turn).
+    """
+    msgs: list[BaseMessage] = [
+        SystemMessage(content="system"),
+        HumanMessage(content="hi"),
+        AIMessage(content="hello"),
+    ]
+    turns = split_into_turns(msgs)
+    # SystemMessage groups with the first turn
+    assert len(turns) == 1
+    assert len(turns[0]) == 3
+
+
+def _make_turn(user_content: str, ai_content: str) -> list:
+    """Helper to create a simple user-assistant turn."""
+    return [HumanMessage(content=user_content), AIMessage(content=ai_content)]
+
+
+def test_trim_no_op_when_under_limit() -> None:
+    """Returns None when turns <= max_turns (no modification needed)."""
+    msgs = [
+        SystemMessage(content="system prompt"),
+        *_make_turn("q1", "a1"),
+        *_make_turn("q2", "a2"),
+    ]
+    state = {"messages": msgs}
+    with patch("src.agent.middleware.get_settings") as mock_settings:
+        mock_settings.return_value = MagicMock(max_turns=5)
+        result = _trim_messages_by_turns_impl(state, MagicMock())
+    assert result is None
+
+
+def test_trim_keeps_last_n_turns() -> None:
+    """Trims to last max_turns turns, preserving system message."""
+    msgs = [
+        SystemMessage(content="system prompt"),
+        *_make_turn("q1", "a1"),
+        *_make_turn("q2", "a2"),
+        *_make_turn("q3", "a3"),
+        *_make_turn("q4", "a4"),
+    ]
+    state = {"messages": msgs}
+    with patch("src.agent.middleware.get_settings") as mock_settings:
+        mock_settings.return_value = MagicMock(max_turns=2)
+        result = _trim_messages_by_turns_impl(state, MagicMock())
+    assert result is not None
+    trimmed = result["messages"]
+    # System message + 2 turns (4 messages) = 5
+    assert len(trimmed) == 5
+    assert isinstance(trimmed[0], SystemMessage)
+    assert trimmed[1].content == "q3"
+    assert trimmed[3].content == "q4"
+
+
+def test_trim_preserves_tool_chains() -> None:
+    """Tool call chains within a turn are kept intact."""
+    msgs = [
+        SystemMessage(content="system prompt"),
+        *_make_turn("old", "old-answer"),
+        HumanMessage(content="search something"),
+        AIMessage(content="", tool_calls=[{"name": "search", "args": {"q": "x"}, "id": "1"}]),
+        ToolMessage(content="result", tool_call_id="1"),
+        AIMessage(content="here's what I found"),
+    ]
+    state = {"messages": msgs}
+    with patch("src.agent.middleware.get_settings") as mock_settings:
+        mock_settings.return_value = MagicMock(max_turns=1)
+        result = _trim_messages_by_turns_impl(state, MagicMock())
+    assert result is not None
+    trimmed = result["messages"]
+    # System + 1 turn with tool chain (4 msgs) = 5
+    assert len(trimmed) == 5
+    assert isinstance(trimmed[0], SystemMessage)
+    assert trimmed[1].content == "search something"
+
+
+def test_trim_no_system_message() -> None:
+    """Works correctly when there is no system message."""
+    msgs = [
+        *_make_turn("q1", "a1"),
+        *_make_turn("q2", "a2"),
+        *_make_turn("q3", "a3"),
+    ]
+    state = {"messages": msgs}
+    with patch("src.agent.middleware.get_settings") as mock_settings:
+        mock_settings.return_value = MagicMock(max_turns=1)
+        result = _trim_messages_by_turns_impl(state, MagicMock())
+    assert result is not None
+    trimmed = result["messages"]
+    assert len(trimmed) == 2
+    assert trimmed[0].content == "q3"
+
+
+def test_trim_empty_messages() -> None:
+    """Returns None for empty message list."""
+    state = {"messages": []}
+    with patch("src.agent.middleware.get_settings") as mock_settings:
+        mock_settings.return_value = MagicMock(max_turns=5)
+        result = _trim_messages_by_turns_impl(state, MagicMock())
+    assert result is None

--- a/src/agent/middleware_test.py
+++ b/src/agent/middleware_test.py
@@ -84,6 +84,8 @@ def test_trim_preserves_tool_chains() -> None:
     assert all(isinstance(m, RemoveMessage) for m in trimmed)
     assert trimmed[0].id == "u_1"
     assert trimmed[1].id == "a_1"
+    # Verify kept turn's tool-call chain is preserved (not in trimmed)
+    assert all(m.id not in {"a_2", "t_1", "a_3"} for m in trimmed)
 
 
 def test_trim_no_system_message() -> None:

--- a/src/agent/middleware_test.py
+++ b/src/agent/middleware_test.py
@@ -2,86 +2,24 @@
 
 from unittest.mock import MagicMock, patch
 
-from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    RemoveMessage,
+    SystemMessage,
+    ToolMessage,
+)
 
-from src.agent.middleware import _trim_messages_by_turns_impl, split_into_turns
-
-
-def test_split_single_turn() -> None:
-    """A single user-assistant exchange is one turn."""
-    msgs: list[BaseMessage] = [
-        HumanMessage(content="hi"),
-        AIMessage(content="hello"),
-    ]
-    turns = split_into_turns(msgs)
-    assert len(turns) == 1
-    assert len(turns[0]) == 2
+from src.agent.middleware import _trim_messages_by_turns_impl
 
 
-def test_split_multiple_turns() -> None:
-    """Each HumanMessage starts a new turn."""
-    msgs: list[BaseMessage] = [
-        HumanMessage(content="q1"),
-        AIMessage(content="a1"),
-        HumanMessage(content="q2"),
-        AIMessage(content="a2"),
-        HumanMessage(content="q3"),
-        AIMessage(content="a3"),
-    ]
-    turns = split_into_turns(msgs)
-    assert len(turns) == 3
-
-
-def test_split_turn_with_tool_calls() -> None:
-    """Tool call chains stay within the same turn."""
-    msgs: list[BaseMessage] = [
-        HumanMessage(content="search something"),
-        AIMessage(content="", tool_calls=[{"name": "search", "args": {"q": "x"}, "id": "1"}]),
-        ToolMessage(content="result", tool_call_id="1"),
-        AIMessage(content="here's what I found"),
-    ]
-    turns = split_into_turns(msgs)
-    assert len(turns) == 1
-    assert len(turns[0]) == 4
-
-
-def test_split_orphan_ai_messages() -> None:
-    """Standalone AIMessages before the first HumanMessage are grouped with the first turn."""
-    msgs: list[BaseMessage] = [
-        AIMessage(content="reminder"),
-        HumanMessage(content="thanks"),
-        AIMessage(content="you're welcome"),
-    ]
-    turns = split_into_turns(msgs)
-    assert len(turns) == 1
-    assert len(turns[0]) == 3
-
-
-def test_split_empty_list() -> None:
-    """Empty message list returns empty turns."""
-    turns = split_into_turns([])
-    assert turns == []
-
-
-def test_split_excludes_system_messages() -> None:
-    """SystemMessages should not be passed to split_into_turns.
-
-    This test documents that if they are, they don't start turns
-    (they'd be grouped with the next turn).
-    """
-    msgs: list[BaseMessage] = [
-        SystemMessage(content="system"),
-        HumanMessage(content="hi"),
-        AIMessage(content="hello"),
-    ]
-    turns = split_into_turns(msgs)
-    # SystemMessage groups with the first turn
-    assert len(turns) == 1
-    assert len(turns[0]) == 3
-
-
-def _make_turn(user_content: str, ai_content: str) -> list:
+def _make_turn(user_content: str, ai_content: str, turn_id: str = "") -> list:
     """Helper to create a simple user-assistant turn."""
+    if turn_id:
+        return [
+            HumanMessage(content=user_content, id=f"u_{turn_id}"),
+            AIMessage(content=ai_content, id=f"a_{turn_id}"),
+        ]
     return [HumanMessage(content=user_content), AIMessage(content=ai_content)]
 
 
@@ -100,13 +38,13 @@ def test_trim_no_op_when_under_limit() -> None:
 
 
 def test_trim_keeps_last_n_turns() -> None:
-    """Trims to last max_turns turns, preserving system message."""
+    """Trims to last max_turns turns, returning RemoveMessage objects for dropped turns."""
     msgs = [
-        SystemMessage(content="system prompt"),
-        *_make_turn("q1", "a1"),
-        *_make_turn("q2", "a2"),
-        *_make_turn("q3", "a3"),
-        *_make_turn("q4", "a4"),
+        SystemMessage(content="system prompt", id="sys_1"),
+        *_make_turn("q1", "a1", "1"),
+        *_make_turn("q2", "a2", "2"),
+        *_make_turn("q3", "a3", "3"),
+        *_make_turn("q4", "a4", "4"),
     ]
     state = {"messages": msgs}
     with patch("src.agent.middleware.get_settings") as mock_settings:
@@ -114,22 +52,26 @@ def test_trim_keeps_last_n_turns() -> None:
         result = _trim_messages_by_turns_impl(state, MagicMock())
     assert result is not None
     trimmed = result["messages"]
-    # System message + 2 turns (4 messages) = 5
-    assert len(trimmed) == 5
-    assert isinstance(trimmed[0], SystemMessage)
-    assert trimmed[1].content == "q3"
-    assert trimmed[3].content == "q4"
+    # Should drop turns 1 and 2 (4 messages total)
+    assert len(trimmed) == 4
+    assert all(isinstance(m, RemoveMessage) for m in trimmed)
+    assert trimmed[0].id == "u_1"
+    assert trimmed[1].id == "a_1"
+    assert trimmed[2].id == "u_2"
+    assert trimmed[3].id == "a_2"
 
 
 def test_trim_preserves_tool_chains() -> None:
     """Tool call chains within a turn are kept intact."""
     msgs = [
-        SystemMessage(content="system prompt"),
-        *_make_turn("old", "old-answer"),
-        HumanMessage(content="search something"),
-        AIMessage(content="", tool_calls=[{"name": "search", "args": {"q": "x"}, "id": "1"}]),
-        ToolMessage(content="result", tool_call_id="1"),
-        AIMessage(content="here's what I found"),
+        SystemMessage(content="system prompt", id="sys_1"),
+        *_make_turn("old", "old-answer", "1"),
+        HumanMessage(content="search something", id="u_2"),
+        AIMessage(
+            content="", tool_calls=[{"name": "search", "args": {"q": "x"}, "id": "1"}], id="a_2"
+        ),
+        ToolMessage(content="result", tool_call_id="1", id="t_1"),
+        AIMessage(content="here's what I found", id="a_3"),
     ]
     state = {"messages": msgs}
     with patch("src.agent.middleware.get_settings") as mock_settings:
@@ -137,18 +79,19 @@ def test_trim_preserves_tool_chains() -> None:
         result = _trim_messages_by_turns_impl(state, MagicMock())
     assert result is not None
     trimmed = result["messages"]
-    # System + 1 turn with tool chain (4 msgs) = 5
-    assert len(trimmed) == 5
-    assert isinstance(trimmed[0], SystemMessage)
-    assert trimmed[1].content == "search something"
+    # Should drop the first turn (2 messages)
+    assert len(trimmed) == 2
+    assert all(isinstance(m, RemoveMessage) for m in trimmed)
+    assert trimmed[0].id == "u_1"
+    assert trimmed[1].id == "a_1"
 
 
 def test_trim_no_system_message() -> None:
     """Works correctly when there is no system message."""
     msgs = [
-        *_make_turn("q1", "a1"),
-        *_make_turn("q2", "a2"),
-        *_make_turn("q3", "a3"),
+        *_make_turn("q1", "a1", "1"),
+        *_make_turn("q2", "a2", "2"),
+        *_make_turn("q3", "a3", "3"),
     ]
     state = {"messages": msgs}
     with patch("src.agent.middleware.get_settings") as mock_settings:
@@ -156,8 +99,13 @@ def test_trim_no_system_message() -> None:
         result = _trim_messages_by_turns_impl(state, MagicMock())
     assert result is not None
     trimmed = result["messages"]
-    assert len(trimmed) == 2
-    assert trimmed[0].content == "q3"
+    # Should drop turns 1 and 2 (4 messages)
+    assert len(trimmed) == 4
+    assert all(isinstance(m, RemoveMessage) for m in trimmed)
+    assert trimmed[0].id == "u_1"
+    assert trimmed[1].id == "a_1"
+    assert trimmed[2].id == "u_2"
+    assert trimmed[3].id == "a_2"
 
 
 def test_trim_empty_messages() -> None:
@@ -165,5 +113,40 @@ def test_trim_empty_messages() -> None:
     state = {"messages": []}
     with patch("src.agent.middleware.get_settings") as mock_settings:
         mock_settings.return_value = MagicMock(max_turns=5)
+        result = _trim_messages_by_turns_impl(state, MagicMock())
+    assert result is None
+
+
+def test_turn_counted_by_human_messages() -> None:
+    """A turn is counted by HumanMessage — AI/Tool messages don't increment the count."""
+    msgs = [
+        SystemMessage(content="system prompt", id="sys_1"),
+        HumanMessage(content="q1", id="u_1"),
+        AIMessage(content="", tool_calls=[{"name": "t", "args": {}, "id": "c1"}], id="a_1"),
+        ToolMessage(content="result", tool_call_id="c1", id="t_1"),
+        AIMessage(content="final", id="a_2"),
+        HumanMessage(content="q2", id="u_2"),
+        AIMessage(content="reply", id="a_3"),
+    ]
+    state = {"messages": msgs}
+    with patch("src.agent.middleware.get_settings") as mock_settings:
+        # max_turns=2 means keep 2 HumanMessages worth of turns
+        mock_settings.return_value = MagicMock(max_turns=2)
+        result = _trim_messages_by_turns_impl(state, MagicMock())
+    # 2 HumanMessages == 2 turns, so nothing should be trimmed
+    assert result is None
+
+
+def test_trim_no_op_at_exact_limit() -> None:
+    """Returns None when turn count exactly equals max_turns."""
+    msgs = [
+        SystemMessage(content="system prompt", id="sys_1"),
+        *_make_turn("q1", "a1", "1"),
+        *_make_turn("q2", "a2", "2"),
+        *_make_turn("q3", "a3", "3"),
+    ]
+    state = {"messages": msgs}
+    with patch("src.agent.middleware.get_settings") as mock_settings:
+        mock_settings.return_value = MagicMock(max_turns=3)
         result = _trim_messages_by_turns_impl(state, MagicMock())
     assert result is None

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -61,6 +61,7 @@ class Settings(BaseSettings):
     llm_provider_base_url: str = "https://api.openai.com/v1"
     embedding_model: str = "gemini-embedding-001"
     search_top_k: int = Field(default=3, ge=1, le=100)
+    max_turns: int = Field(default=5, ge=1, le=50)
 
     # Webhook (set WEBHOOK_URL to enable webhook mode; leave empty for polling)
     webhook_url: str = ""

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -29,6 +29,7 @@ class Settings(BaseSettings):
         llm_provider_base_url: Base URL for the LLM provider API.
         embedding_model: Embedding model name for vector generation.
         search_top_k: Number of top results to return from search.
+        max_turns: Number of turns to keep (a turn = one user message + all AI/tool messages).
         webhook_url: Public HTTPS URL to enable webhook mode (empty for polling).
         webhook_secret: Secret token for Telegram webhook request verification.
         port: Port for the webhook server.

--- a/src/core/config_test.py
+++ b/src/core/config_test.py
@@ -247,3 +247,23 @@ def test_max_turns_from_env() -> None:
         with patch.object(Settings, "model_config", _NO_DOTENV):
             settings = Settings()  # type: ignore[call-arg]
     assert settings.max_turns == 10
+
+
+def test_max_turns_below_min() -> None:
+    """max_turns rejects values below minimum (< 1)."""
+    from src.core.config import Settings
+
+    with patch.dict(os.environ, {**BASE_ENV, "MAX_TURNS": "0"}, clear=True):
+        with patch.object(Settings, "model_config", _NO_DOTENV):
+            with pytest.raises(ValidationError):
+                Settings()  # type: ignore[call-arg]
+
+
+def test_max_turns_above_max() -> None:
+    """max_turns rejects values above maximum (> 50)."""
+    from src.core.config import Settings
+
+    with patch.dict(os.environ, {**BASE_ENV, "MAX_TURNS": "51"}, clear=True):
+        with patch.object(Settings, "model_config", _NO_DOTENV):
+            with pytest.raises(ValidationError):
+                Settings()  # type: ignore[call-arg]

--- a/src/core/config_test.py
+++ b/src/core/config_test.py
@@ -227,3 +227,23 @@ def test_settings_database_url_is_required() -> None:
         with patch.object(Settings, "model_config", _NO_DOTENV):
             with pytest.raises(ValidationError):
                 Settings()  # type: ignore[call-arg]
+
+
+def test_max_turns_default() -> None:
+    """max_turns defaults to 5 when env var is not set."""
+    from src.core.config import Settings
+
+    with patch.dict(os.environ, BASE_ENV, clear=True):
+        with patch.object(Settings, "model_config", _NO_DOTENV):
+            settings = Settings()  # type: ignore[call-arg]
+    assert settings.max_turns == 5
+
+
+def test_max_turns_from_env() -> None:
+    """max_turns reads from MAX_TURNS env var."""
+    from src.core.config import Settings
+
+    with patch.dict(os.environ, {**BASE_ENV, "MAX_TURNS": "10"}, clear=True):
+        with patch.object(Settings, "model_config", _NO_DOTENV):
+            settings = Settings()  # type: ignore[call-arg]
+    assert settings.max_turns == 10

--- a/src/db/seed_memories_test.py
+++ b/src/db/seed_memories_test.py
@@ -37,7 +37,10 @@ async def test_imports_all_entries_from_json(tmp_path: Path) -> None:
     test_file = tmp_path / "test_seed.json"
     test_file.write_text(json.dumps(test_data))
 
-    with patch("src.db.seed_memories.save_memory", new_callable=AsyncMock) as mock_save:
+    with (
+        patch("src.db.seed_memories.save_memory", new_callable=AsyncMock) as mock_save,
+        patch("src.db.seed_memories.asyncio.sleep", new_callable=AsyncMock),
+    ):
         mock_save.return_value = {"id": "test-id", "content": "test"}
 
         result = await seed_memories(str(test_file), user_settings_id="usr-123")


### PR DESCRIPTION
Fix #33 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable conversation history trimming with a `MAX_TURNS` environment variable to manage context window size.
  * Default maximum turns set to 5, with a configurable range of 1-50 turns per conversation.

* **Documentation**
  * Added `MAX_TURNS` environment variable to `.env.example` with usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->