### PR TITLE
Recycle stale Postgres pool connections behind Supavisor

### DIFF
--- a/src/db/checkpointer.py
+++ b/src/db/checkpointer.py
@@ -40,7 +40,23 @@ async def aget_checkpointer() -> AsyncPostgresSaver:
         settings = get_settings()
         pool = AsyncConnectionPool(
             settings.database_url.get_secret_value(),
-            kwargs={"row_factory": dict_row, "autocommit": True},
+            kwargs={
+                "row_factory": dict_row,
+                "autocommit": True,
+                # Disable auto-prepared statements. Required for Supabase's
+                # transaction pooler (port 6543) and harmless on session
+                # connections; without this, recycled backends raise
+                # "DbHandler exited" on the next aget_tuple call.
+                "prepare_threshold": None,
+            },
+            # Validate a connection before handing it out so stale/closed
+            # connections (e.g. killed by Supavisor) get discarded instead
+            # of being returned to the caller.
+            check=AsyncConnectionPool.check_connection,
+            # Rotate connections proactively so we never hold one long
+            # enough for the upstream pooler to drop it from under us.
+            max_idle=300,  # 5 min
+            max_lifetime=1800,  # 30 min
             open=False,
         )
         await pool.open()

--- a/src/db/checkpointer_test.py
+++ b/src/db/checkpointer_test.py
@@ -99,6 +99,43 @@ async def test_aclose_checkpointer_noop_when_none() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_checkpointer_configures_pool_for_pooler_resilience() -> None:
+    """Pool is configured to survive Supavisor backend recycling.
+
+    Regression guard for "DbHandler exited" errors caused by stale
+    pooled connections after idle periods. Verifies that:
+    - prepared statements are disabled (prepare_threshold=None)
+    - connections are health-checked before checkout
+    - max_idle / max_lifetime are set to recycle connections
+    """
+    from src.db.checkpointer import aget_checkpointer
+
+    mock_settings = MagicMock()
+    mock_settings.database_url.get_secret_value.return_value = (
+        "postgresql://user:pass@localhost:5432/db"
+    )
+
+    mock_pool = MagicMock()
+    mock_pool.open = AsyncMock()
+    mock_saver = MagicMock()
+    mock_saver.setup = AsyncMock()
+
+    with (
+        patch("src.core.config.get_settings", return_value=mock_settings),
+        patch("src.db.checkpointer.AsyncConnectionPool", return_value=mock_pool) as mock_pool_cls,
+        patch("src.db.checkpointer.AsyncPostgresSaver", return_value=mock_saver),
+    ):
+        await aget_checkpointer()
+
+    _, kwargs = mock_pool_cls.call_args
+    assert kwargs["kwargs"]["prepare_threshold"] is None
+    assert kwargs["kwargs"]["autocommit"] is True
+    assert kwargs["check"] is mock_pool_cls.check_connection
+    assert kwargs["max_idle"] > 0
+    assert kwargs["max_lifetime"] > kwargs["max_idle"]
+
+
+@pytest.mark.asyncio
 async def test_get_checkpointer_closes_pool_on_setup_failure() -> None:
     """Test that pool is closed when saver.setup() fails."""
     from src.db.checkpointer import aget_checkpointer


### PR DESCRIPTION
The AsyncPostgresSaver pool occasionally returned connections that Supavisor had already closed during idle periods, causing psycopg.errors.InternalError_: DbHandler exited on the first message after the bot sat idle.

Configures the pool with check_connection, max_idle=300, and max_lifetime=1800, and disables auto-prepared statements (prepare_threshold=None) so connections survive Supavisor backend swaps.